### PR TITLE
fix crash with ess-remote

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -122,6 +122,7 @@ emacs_version <- function() {
   ver <- gsub("'", "", ver)
   ver <- strsplit(ver, ",", fixed = TRUE)[[1]]
   ver <- strsplit(ver, ".", fixed = TRUE)[[1]]
+  ver <- gsub("'", "", ver)
   as.numeric(ver)
 }
 


### PR DESCRIPTION
Fix 

```
 Error : .onLoad failed in loadNamespace() for 'crayon', details:
         call: if (inside_emacs() && emacs_version()[1] >= 23) {
         error: missing value where TRUE/FALSE needed
         In addition: Warning message:
         In emacs_version() : NAs introduced by coercion

```

when using via ess-remote
